### PR TITLE
Fix busy wait in Floyd.run_assistant

### DIFF
--- a/floyd.py
+++ b/floyd.py
@@ -1,4 +1,5 @@
 from typing import Optional, Dict, Any
+import time
 
 from openai import OpenAI
 
@@ -58,8 +59,16 @@ class Floyd:
                 thread_id=thread_id,
                 run_id=run.id
             )
-            if run.status == "completed":
+            if run.status in {
+                "completed",
+                "failed",
+                "cancelled",
+                "expired",
+                "requires_action",
+            }:
                 break
+            # Avoid hammering the API in a tight loop
+            time.sleep(1)
 
         # Get messages
         messages = self.client.beta.threads.messages.list(thread_id=thread_id)


### PR DESCRIPTION
## Summary
- handle additional run states
- add `time.sleep` to avoid tight loop

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_686af0a18fdc832ca36f4551f830572e