### PR TITLE
Rename assistant id

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import os
 from floyd import Floyd
 import json
 
+FloydBasicResponseAssistantId = os.environ['OPENAI_FLOYD_BASIC_RESPONSE_ASSISTANT_ID']
+
 def lambda_handler(event, context):
     try:
         # Parse the incoming request body for the question
@@ -14,8 +16,7 @@ def lambda_handler(event, context):
         question = data.get('question', 'What is your question?')
 
         # Initialize Floyd
-        assistant_id = os.environ['OPENAI_ASSISTANT_ID']
-        floyd = Floyd(assistant_id)
+        floyd = Floyd(FloydBasicResponseAssistantId)
 
         # Use the question from the request
         response = floyd.chat(question)

--- a/test_lambda.py
+++ b/test_lambda.py
@@ -5,13 +5,13 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-ASSISTANT_ID = os.getenv('OPENAI_ASSISTANT_ID')
-if not ASSISTANT_ID:
-    raise ValueError("OPENAI_ASSISTANT_ID environment variable is not set")
+FloydBasicResponseAssistantId = os.getenv('OPENAI_FLOYD_BASIC_RESPONSE_ASSISTANT_ID')
+if not FloydBasicResponseAssistantId:
+    raise ValueError("OPENAI_FLOYD_BASIC_RESPONSE_ASSISTANT_ID environment variable is not set")
 
 def test_floyd():
     # Initialize Floyd
-    floyd = Floyd(ASSISTANT_ID)
+    floyd = Floyd(FloydBasicResponseAssistantId)
     
     # Test a single message
     print("\nTesting single message:")


### PR DESCRIPTION
## Summary
- rename default assistant ID to FloydBasicResponseAssistantId
- expect env var `OPENAI_FLOYD_BASIC_RESPONSE_ASSISTANT_ID`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_686af43914f4832cb83820f035aa98dd