### PR TITLE
Add router assistant selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,20 @@
 import os
 from floyd import Floyd
+from router import Router
 import json
 
 # Map assistant types to their OpenAI assistant IDs
 ASSISTANT_MAP = {
-    "basic_response": os.environ.get("OPENAI_FLOYD_BASIC_RESPONSE_ASSISTANT_ID")
+    "basic_response": os.environ.get("OPENAI_FLOYD_BASIC_RESPONSE_ASSISTANT_ID"),
+    "router": os.environ.get("OPENAI_ROUTER_ASSISTANT_ID"),
+    "DoSomething": os.environ.get("OPENAI_DOSOMETHING_ASSISTANT_ID"),
+    "PickUp": os.environ.get("OPENAI_PICKUP_ASSISTANT_ID"),
+    "GoSomewhere": os.environ.get("OPENAI_GOSOMEWHERE_ASSISTANT_ID"),
+    "AskQuestion": os.environ.get("OPENAI_ASKQUESTION_ASSISTANT_ID"),
+    "GiveInstruction": os.environ.get("OPENAI_GIVEINSTRUCTION_ASSISTANT_ID"),
+    "SocialEmotional": os.environ.get("OPENAI_SOCIALEMOTIONAL_ASSISTANT_ID"),
+    "MetaCommand": os.environ.get("OPENAI_METACOMMAND_ASSISTANT_ID"),
+    "Nonsense": os.environ.get("OPENAI_NONSENSE_ASSISTANT_ID")
 }
 
 def lambda_handler(event, context):
@@ -31,10 +41,17 @@ def lambda_handler(event, context):
                 'body': json.dumps({'error': 'Unknown assistant type'})
             }
 
-        # Initialize Floyd with the matching assistant ID
-        floyd = Floyd(assistant_id)
+        if assistant_type == 'router':
+            router = Router(assistant_id)
+            route = router.route(prompt)
+            assistant_id = ASSISTANT_MAP.get(route)
+            if not assistant_id:
+                return {
+                    'statusCode': 400,
+                    'body': json.dumps({'error': 'Unknown route'})
+                }
 
-        # Use the prompt from the request
+        floyd = Floyd(assistant_id)
         response = floyd.chat(prompt)
         result1 = {"single_message": response['content']}
 

--- a/router.py
+++ b/router.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from floyd import Floyd
+
+class Router(Floyd):
+    """Router class that determines which assistant to use based on a prompt."""
+
+    def __init__(self, assistant_id: str, api_key: Optional[str] = None):
+        super().__init__(assistant_id, api_key)
+
+    def route(self, prompt: str) -> str:
+        """Return the routing classification for the given prompt."""
+        response = self.chat(prompt)
+        return response.get('content')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,16 +8,22 @@ from unittest.mock import MagicMock
 import pytest
 
 
-def load_main(monkeypatch, assistant_id='aid'):
+def load_main(monkeypatch, assistant_id='aid', router_id='rid', route_ids=None):
     """Import main module with mocked dependencies."""
     openai_module = ModuleType('openai')
     openai_module.OpenAI = MagicMock(return_value=MagicMock())
     monkeypatch.setitem(sys.modules, 'openai', openai_module)
     monkeypatch.setenv('OPENAI_FLOYD_BASIC_RESPONSE_ASSISTANT_ID', assistant_id)
+    monkeypatch.setenv('OPENAI_ROUTER_ASSISTANT_ID', router_id)
+    if route_ids:
+        for name, val in route_ids.items():
+            monkeypatch.setenv(f'OPENAI_{name.upper()}_ASSISTANT_ID', val)
     repo_root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(repo_root))
     if 'floyd' in sys.modules:
         del sys.modules['floyd']
+    if 'router' in sys.modules:
+        del sys.modules['router']
     if 'main' in sys.modules:
         del sys.modules['main']
     main = importlib.import_module('main')
@@ -51,6 +57,29 @@ def test_lambda_success(monkeypatch):
     data = json.loads(resp['body'])
     assert data['results']['single_message'] == 'resp'
     main.Floyd.assert_called_once_with('aid')
+    mock_floyd.chat.assert_called_once_with('hello')
+
+
+def test_lambda_router(monkeypatch):
+    main = load_main(
+        monkeypatch,
+        router_id='rid',
+        route_ids={'ASKQUESTION': 'qid'}
+    )
+    mock_router = MagicMock()
+    mock_router.route.return_value = 'AskQuestion'
+    monkeypatch.setattr(main, 'Router', MagicMock(return_value=mock_router))
+    mock_floyd = MagicMock()
+    mock_floyd.chat.return_value = {'role': 'assistant', 'content': 'resp'}
+    monkeypatch.setattr(main, 'Floyd', MagicMock(return_value=mock_floyd))
+    event = {'assistant': 'router', 'prompt': 'hello'}
+    resp = main.lambda_handler(event, None)
+    assert resp['statusCode'] == 200
+    data = json.loads(resp['body'])
+    assert data['results']['single_message'] == 'resp'
+    main.Router.assert_called_once_with('rid')
+    mock_router.route.assert_called_once_with('hello')
+    main.Floyd.assert_called_once_with('qid')
     mock_floyd.chat.assert_called_once_with('hello')
 
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+
+def load_router(monkeypatch):
+    """Import router module with mocked dependencies."""
+    client = MagicMock()
+    openai_module = ModuleType('openai')
+    openai_module.OpenAI = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, 'openai', openai_module)
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(repo_root))
+    if 'floyd' in sys.modules:
+        del sys.modules['floyd']
+    if 'router' in sys.modules:
+        del sys.modules['router']
+    router = importlib.import_module('router')
+    return router, client, openai_module.OpenAI
+
+
+def test_route_returns_content(monkeypatch):
+    router_mod, client, openai_cls = load_router(monkeypatch)
+    instance = router_mod.Router('aid')
+    monkeypatch.setattr(instance, 'chat', MagicMock(return_value={'content': 'AskQuestion'}))
+    result = instance.route('hello')
+    instance.chat.assert_called_once_with('hello')
+    assert result == 'AskQuestion'


### PR DESCRIPTION
## Summary
- create a `Router` class to classify prompts
- expand `ASSISTANT_MAP` with router and routing targets
- route requests through `Router` when `assistant` is `router`
- add tests for routing behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aface918c832cafcd320c94f00412