### PR TITLE
Add RewriteSecondPerson assistant

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 from floyd import Floyd
 from router import Router
+from rewrite_second_person import RewriteSecondPerson
 import json
 
 # Map assistant types to their OpenAI assistant IDs
@@ -14,7 +15,8 @@ ASSISTANT_MAP = {
     "GiveInstruction": os.environ.get("OPENAI_GIVEINSTRUCTION_ASSISTANT_ID"),
     "SocialEmotional": os.environ.get("OPENAI_SOCIALEMOTIONAL_ASSISTANT_ID"),
     "MetaCommand": os.environ.get("OPENAI_METACOMMAND_ASSISTANT_ID"),
-    "Nonsense": os.environ.get("OPENAI_NONSENSE_ASSISTANT_ID")
+    "Nonsense": os.environ.get("OPENAI_NONSENSE_ASSISTANT_ID"),
+    "RewriteSecondPerson": os.environ.get("OPENAI_REWRITESECONDPERSON_ASSISTANT_ID"),
 }
 
 def lambda_handler(event, context):
@@ -42,6 +44,15 @@ def lambda_handler(event, context):
             }
 
         if assistant_type == 'router':
+            rewrite_id = ASSISTANT_MAP.get('RewriteSecondPerson')
+            rewriter = RewriteSecondPerson(rewrite_id)
+            new_prompt = rewriter.rewrite(prompt)
+            if new_prompt.strip().lower() == 'no':
+                return {
+                    'statusCode': 200,
+                    'body': json.dumps({'results': {'single_message': 'no'}})
+                }
+            prompt = new_prompt
             router = Router(assistant_id)
             route = router.route(prompt)
             assistant_id = ASSISTANT_MAP.get(route)

--- a/rewrite_second_person.py
+++ b/rewrite_second_person.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from floyd import Floyd
+
+
+class RewriteSecondPerson(Floyd):
+    """Assistant wrapper that rewrites prompts into second person."""
+
+    def __init__(self, assistant_id: str, api_key: Optional[str] = None):
+        super().__init__(assistant_id, api_key)
+
+    def rewrite(self, prompt: str) -> str:
+        """Return the rewritten prompt."""
+        response = self.chat(prompt)
+        return response.get('content')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,6 +26,8 @@ def load_main(monkeypatch, assistant_id='aid', router_id='rid', route_ids=None):
         del sys.modules['router']
     if 'main' in sys.modules:
         del sys.modules['main']
+    if 'rewrite_second_person' in sys.modules:
+        del sys.modules['rewrite_second_person']
     main = importlib.import_module('main')
     return main
 
@@ -64,8 +66,11 @@ def test_lambda_router(monkeypatch):
     main = load_main(
         monkeypatch,
         router_id='rid',
-        route_ids={'ASKQUESTION': 'qid'}
+        route_ids={'ASKQUESTION': 'qid', 'REWRITESECONDPERSON': 'rewid'}
     )
+    mock_rewriter = MagicMock()
+    mock_rewriter.rewrite.return_value = 'rewritten'
+    monkeypatch.setattr(main, 'RewriteSecondPerson', MagicMock(return_value=mock_rewriter))
     mock_router = MagicMock()
     mock_router.route.return_value = 'AskQuestion'
     monkeypatch.setattr(main, 'Router', MagicMock(return_value=mock_router))
@@ -77,10 +82,34 @@ def test_lambda_router(monkeypatch):
     assert resp['statusCode'] == 200
     data = json.loads(resp['body'])
     assert data['results']['single_message'] == 'resp'
+    main.RewriteSecondPerson.assert_called_once_with('rewid')
+    mock_rewriter.rewrite.assert_called_once_with('hello')
     main.Router.assert_called_once_with('rid')
-    mock_router.route.assert_called_once_with('hello')
+    mock_router.route.assert_called_once_with('rewritten')
     main.Floyd.assert_called_once_with('qid')
-    mock_floyd.chat.assert_called_once_with('hello')
+    mock_floyd.chat.assert_called_once_with('rewritten')
+
+
+def test_lambda_router_rewrite_no(monkeypatch):
+    main = load_main(
+        monkeypatch,
+        router_id='rid',
+        route_ids={'REWRITESECONDPERSON': 'rewid'}
+    )
+    mock_rewriter = MagicMock()
+    mock_rewriter.rewrite.return_value = 'no'
+    monkeypatch.setattr(main, 'RewriteSecondPerson', MagicMock(return_value=mock_rewriter))
+    monkeypatch.setattr(main, 'Router', MagicMock())
+    monkeypatch.setattr(main, 'Floyd', MagicMock())
+    event = {'assistant': 'router', 'prompt': 'hello'}
+    resp = main.lambda_handler(event, None)
+    assert resp['statusCode'] == 200
+    data = json.loads(resp['body'])
+    assert data['results']['single_message'] == 'no'
+    main.RewriteSecondPerson.assert_called_once_with('rewid')
+    mock_rewriter.rewrite.assert_called_once_with('hello')
+    main.Router.assert_not_called()
+    main.Floyd.assert_not_called()
 
 
 def test_lambda_exception(monkeypatch):

--- a/tests/test_rewrite_second_person.py
+++ b/tests/test_rewrite_second_person.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+
+def load_rewriter(monkeypatch):
+    client = MagicMock()
+    openai_module = ModuleType('openai')
+    openai_module.OpenAI = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, 'openai', openai_module)
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(repo_root))
+    if 'floyd' in sys.modules:
+        del sys.modules['floyd']
+    if 'rewrite_second_person' in sys.modules:
+        del sys.modules['rewrite_second_person']
+    mod = importlib.import_module('rewrite_second_person')
+    return mod, client, openai_module.OpenAI
+
+
+def test_rewrite_returns_content(monkeypatch):
+    mod, client, openai_cls = load_rewriter(monkeypatch)
+    instance = mod.RewriteSecondPerson('aid')
+    monkeypatch.setattr(instance, 'chat', MagicMock(return_value={'content': 'out'}))
+    result = instance.rewrite('hi')
+    instance.chat.assert_called_once_with('hi')
+    assert result == 'out'


### PR DESCRIPTION
## Summary
- create RewriteSecondPerson class to rewrite prompts
- integrate RewriteSecondPerson into lambda request flow
- test RewriteSecondPerson module
- update router path tests to cover rewriting logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686afefc09a8832c9d4d15630dd62e08