### PR TITLE
Add rewrite API endpoint and adjust routing

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 import os
 from floyd import Floyd
 from router import Router
-from rewrite_second_person import RewriteSecondPerson
 import json
 
 # Map assistant types to their OpenAI assistant IDs
@@ -50,18 +49,6 @@ def lambda_handler(event, context):
 
         if assistant_type == 'router':
             print("Processing router assistant type")
-            rewrite_id = ASSISTANT_MAP.get('RewriteSecondPerson')
-            print(f"Using RewriteSecondPerson assistant id: {rewrite_id}")
-            rewriter = RewriteSecondPerson(rewrite_id)
-            new_prompt = rewriter.rewrite(prompt)
-            print("Rewritten prompt:", new_prompt)
-            if new_prompt.strip().lower() == 'no':
-                print("Rewrite returned 'no'; short circuiting")
-                return {
-                    'statusCode': 200,
-                    'body': json.dumps({'results': {'single_message': 'no'}})
-                }
-            prompt = new_prompt
             router = Router(assistant_id)
             print(f"Routing with assistant id: {assistant_id}")
             route = router.route(prompt)

--- a/manual_test_rewrite_second_person.py
+++ b/manual_test_rewrite_second_person.py
@@ -1,0 +1,15 @@
+import json
+from rewrite_second_person import lambda_handler
+
+
+def main():
+    """Load rewrite_event.json and invoke the rewrite lambda_handler."""
+    with open('rewrite_event.json', 'r') as f:
+        event = json.load(f)
+
+    response = lambda_handler(event, None)
+    print(json.dumps(response, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/rewrite_event.json
+++ b/rewrite_event.json
@@ -1,0 +1,3 @@
+{
+  "prompt": "rewrite this prompt into second person"
+}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -66,11 +66,8 @@ def test_lambda_router(monkeypatch):
     main = load_main(
         monkeypatch,
         router_id='rid',
-        route_ids={'ASKQUESTION': 'qid', 'REWRITESECONDPERSON': 'rewid'}
+        route_ids={'ASKQUESTION': 'qid'}
     )
-    mock_rewriter = MagicMock()
-    mock_rewriter.rewrite.return_value = 'rewritten'
-    monkeypatch.setattr(main, 'RewriteSecondPerson', MagicMock(return_value=mock_rewriter))
     mock_router = MagicMock()
     mock_router.route.return_value = 'AskQuestion'
     monkeypatch.setattr(main, 'Router', MagicMock(return_value=mock_router))
@@ -82,34 +79,11 @@ def test_lambda_router(monkeypatch):
     assert resp['statusCode'] == 200
     data = json.loads(resp['body'])
     assert data['results']['single_message'] == 'resp'
-    main.RewriteSecondPerson.assert_called_once_with('rewid')
-    mock_rewriter.rewrite.assert_called_once_with('hello')
     main.Router.assert_called_once_with('rid')
-    mock_router.route.assert_called_once_with('rewritten')
+    mock_router.route.assert_called_once_with('hello')
     main.Floyd.assert_called_once_with('qid')
-    mock_floyd.chat.assert_called_once_with('rewritten')
+    mock_floyd.chat.assert_called_once_with('hello')
 
-
-def test_lambda_router_rewrite_no(monkeypatch):
-    main = load_main(
-        monkeypatch,
-        router_id='rid',
-        route_ids={'REWRITESECONDPERSON': 'rewid'}
-    )
-    mock_rewriter = MagicMock()
-    mock_rewriter.rewrite.return_value = 'no'
-    monkeypatch.setattr(main, 'RewriteSecondPerson', MagicMock(return_value=mock_rewriter))
-    monkeypatch.setattr(main, 'Router', MagicMock())
-    monkeypatch.setattr(main, 'Floyd', MagicMock())
-    event = {'assistant': 'router', 'prompt': 'hello'}
-    resp = main.lambda_handler(event, None)
-    assert resp['statusCode'] == 200
-    data = json.loads(resp['body'])
-    assert data['results']['single_message'] == 'no'
-    main.RewriteSecondPerson.assert_called_once_with('rewid')
-    mock_rewriter.rewrite.assert_called_once_with('hello')
-    main.Router.assert_not_called()
-    main.Floyd.assert_not_called()
 
 
 def test_lambda_exception(monkeypatch):

--- a/tests/test_rewrite_second_person.py
+++ b/tests/test_rewrite_second_person.py
@@ -1,15 +1,17 @@
 import importlib
+import json
 import sys
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import MagicMock
 
 
-def load_rewriter(monkeypatch):
+def load_rewriter(monkeypatch, rew_id='aid'):
     client = MagicMock()
     openai_module = ModuleType('openai')
     openai_module.OpenAI = MagicMock(return_value=client)
     monkeypatch.setitem(sys.modules, 'openai', openai_module)
+    monkeypatch.setenv('OPENAI_REWRITESECONDPERSON_ASSISTANT_ID', rew_id)
     repo_root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(repo_root))
     if 'floyd' in sys.modules:
@@ -27,3 +29,24 @@ def test_rewrite_returns_content(monkeypatch):
     result = instance.rewrite('hi')
     instance.chat.assert_called_once_with('hi')
     assert result == 'out'
+
+
+def test_lambda_handler_success(monkeypatch):
+    mod, client, openai_cls = load_rewriter(monkeypatch, rew_id='rid')
+    mock_rewriter = MagicMock()
+    mock_rewriter.rewrite.return_value = 'rewritten'
+    monkeypatch.setattr(mod, 'RewriteSecondPerson', MagicMock(return_value=mock_rewriter))
+    event = {'prompt': 'hello'}
+    resp = mod.lambda_handler(event, None)
+    assert resp['statusCode'] == 200
+    data = json.loads(resp['body'])
+    assert data['results']['single_message'] == 'rewritten'
+    mod.RewriteSecondPerson.assert_called_once_with('rid')
+    mock_rewriter.rewrite.assert_called_once_with('hello')
+
+
+def test_lambda_handler_missing_prompt(monkeypatch):
+    mod, _, _ = load_rewriter(monkeypatch)
+    resp = mod.lambda_handler({}, None)
+    assert resp['statusCode'] == 400
+    assert json.loads(resp['body'])['error'] == 'Prompt is required'


### PR DESCRIPTION
## Summary
- add an API handler in `rewrite_second_person`
- skip the rewrite step when routing in `main`
- update tests for new logic and new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688659b488bc832ca61fd607727906d2